### PR TITLE
hotfix CVE-2024-9853

### DIFF
--- a/toolkit.php
+++ b/toolkit.php
@@ -33,19 +33,6 @@ if ( is_admin() ) {
 }
 
 /**
- * Add support for uploading SVG files.
- *
- * @param  array $mimes Currently allowed mime types.
- *
- * @return array
- */
-function idsktk_mime_types( $mimes ) {
-	$mimes['svg'] = 'image/svg+xml';
-	return $mimes;
-}
-add_filter( 'upload_mimes', 'idsktk_mime_types' );
-
-/**
  * Remove automatic paragraphs in widgets.
  */
 remove_filter( 'widget_text_content', 'wpautop' );


### PR DESCRIPTION
Removed the SVG functionality from idsk-toolkit
plugin as not needed.
It is recommended to use plugin for SVG support of own choice.
https://wordpress.org/plugins/search/svg/
Safe SVG confirmed as working
https://wordpress.org/plugins/safe-svg/#description

Closes #1